### PR TITLE
update getbbgdata.py

### DIFF
--- a/fhdataapi/BBG/getbbgdata.py
+++ b/fhdataapi/BBG/getbbgdata.py
@@ -189,7 +189,7 @@ class BBG(object):
                     df = df.append(df_aux)
 
             df['VALUE'] = df['VALUE'].astype(float, errors='ignore')
-            df['TRADE_DATE'] = df['TRADE_DATE'].astype(pd.Timestamp)
+            df['TRADE_DATE'] = pd.to_datetime(df['TRADE_DATE'])
 
             df = pd.pivot_table(data=df, index=['FIELD', 'TRADE_DATE'], columns='TICKER', values='VALUE')
 


### PR DESCRIPTION
line 192 where  df['TRADE_DATE'].astype(pd.Timestamp) we should use pd.to_datetime(df['TRADE_DATE'])
tested in Phyton 3.7, Syper - Anaconda, INSPER BBG terminal
tks